### PR TITLE
Rebasing paths to allow for reverse proxy with path rewriting

### DIFF
--- a/.github/workflows/buildimage.yml
+++ b/.github/workflows/buildimage.yml
@@ -1,0 +1,36 @@
+name: Create and publish a Docker image
+on:
+  push:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -7,11 +7,11 @@ metadata:
     app: kubevirt-manager
     kubevirt-manager.io/version: 1.1.2
 
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubevirt-manager
-
 rules:
   - apiGroups: [""]
     resources: ["nodes", "namespaces"]

--- a/src/app/components/vmlist/vmlist.component.html
+++ b/src/app/components/vmlist/vmlist.component.html
@@ -44,7 +44,7 @@
                   <td style="line-height: 2.2 !important;">{{thisVM.namespace}}</td>
                   <td style="line-height: 2.2 !important;">{{thisVM.name}}</td>
                   <td style="line-height: 2.2 !important;">{{thisVM.instType}}</td>
-                  <td style="line-height: 2.2 !important;">{{thisVM.cores * thisVM.sockets * thisVM.threads}}</td>
+                  <td style="line-height: 2.2 !important;">{{(thisVM.sockets || 0) * (thisVM.sockets || 0) * (thisVM.threads || 0)}}</td>
                   <td style="line-height: 2.2 !important;">{{thisVM.memory}}</td>
                   <td style="line-height: 2.2 !important;">{{thisVM.status}}</td>
                   <td style="line-height: 2.2 !important;">

--- a/src/app/components/vmlist/vmlist.component.ts
+++ b/src/app/components/vmlist/vmlist.component.ts
@@ -104,11 +104,19 @@ export class VmlistComponent implements OnInit {
             }
 
             if(currentVm.instType == "custom") {
-                /* Custom VM has cpu / mem parameters */
-                currentVm.cores = vms[i].spec.template.spec.domain.cpu["cores"];
-                currentVm.sockets = vms[i].spec.template.spec.domain.cpu["sockets"];
-                currentVm.threads = vms[i].spec.template.spec.domain.cpu["threads"];
-                currentVm.memory = vms[i].spec.template.spec.domain.resources.requests["memory"];
+                try {
+                    /* Custom VM has cpu / mem parameters */
+                    currentVm.cores = vms[i].spec.template.spec.domain.cpu["cores"];
+                    currentVm.sockets = vms[i].spec.template.spec.domain.cpu["sockets"];
+                    currentVm.threads = vms[i].spec.template.spec.domain.cpu["threads"];
+                    currentVm.memory = vms[i].spec.template.spec.domain.resources.requests["memory"];
+                } catch (_){
+                    currentVm.cores = currentVm.cores || 0;
+                    currentVm.sockets = currentVm.sockets || 0;
+                    currentVm.threads = currentVm.threads || 0;
+                    currentVm.memory = currentVm.memory || "N/A";
+                }
+
             } else {
                 /* load vCPU / Mem from type */
                 try {

--- a/src/app/components/vncviewer/vncviewer.component.ts
+++ b/src/app/components/vncviewer/vncviewer.component.ts
@@ -29,7 +29,8 @@ export class VNCViewerComponent implements OnInit {
 
         const host = window.location.hostname;
         const port = window.location.port;
-        const path = "k8s/apis/subresources.kubevirt.io/v1alpha3/namespaces/" + this.vmNamespace + "/virtualmachineinstances/" + this.vmName + "/vnc";
+        const rootPath = window.location.pathname.split('/').slice(1,-3).join('/'); // Dropping first `/` and trailing `/vncviewer/<vmNamespace>/<vmName>` from path to get back to "root"
+        const path = rootPath + "/k8s/apis/subresources.kubevirt.io/v1alpha3/namespaces/" + this.vmNamespace + "/virtualmachineinstances/" + this.vmName + "/vnc";
 
         // Build the websocket URL used to connect
         let url = "ws";

--- a/src/app/services/data-volumes.service.ts
+++ b/src/app/services/data-volumes.service.ts
@@ -15,22 +15,22 @@ export class DataVolumesService {
     constructor(private http: HttpClient) { }
 
     getDataVolumes(): Observable<any> {
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         return this.http.get(`${baseUrl}/datavolumes`);
     }
 
     getNamespacedDataVolumes(dvNamespace: string): Observable<any> {
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         return this.http.get(`${baseUrl}/namespaces/${dvNamespace}/datavolumes`);
     }
 
     getDataVolumeInfo(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/datavolumes/${name}`);
     }
 
     deleteDataVolume(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         return this.http.delete(`${baseUrl}/namespaces/${namespace}/datavolumes/${name}`);
     }
 
@@ -40,7 +40,7 @@ export class DataVolumesService {
         thisDv.metadata["namespace"] = dvNamespace;
         thisDv.spec.pvc.resources.requests["storage"] = dvSize + "Gi";
         thisDv.spec.pvc["storageClassName"] = dvSc;
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -55,7 +55,7 @@ export class DataVolumesService {
         thisDv.spec.pvc.resources.requests["storage"] = dvSize + "Gi";
         thisDv.spec.pvc["storageClassName"] = dvSc;
         thisDv.spec.source.http["url"] = dvUrl;
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -71,7 +71,7 @@ export class DataVolumesService {
         thisDv.spec.pvc["storageClassName"] = dvSc;
         thisDv.spec.source.pvc["name"] = fromName;
         thisDv.spec.source.pvc["namespace"] = dvNamespace;
-        var baseUrl ='/k8s/apis/cdi.kubevirt.io/v1beta1';
+        var baseUrl ='./k8s/apis/cdi.kubevirt.io/v1beta1';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'

--- a/src/app/services/k8s-apis.service.ts
+++ b/src/app/services/k8s-apis.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
-const baseUrl ='/k8s/apis'
+const baseUrl ='./k8s/apis'
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/k8s.service.ts
+++ b/src/app/services/k8s.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-const baseUrl ='/k8s/api/v1'
+const baseUrl ='./k8s/api/v1'
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/kube-virt.service.ts
+++ b/src/app/services/kube-virt.service.ts
@@ -11,47 +11,47 @@ export class KubeVirtService {
     constructor(private http: HttpClient) { }
 
     getVMs(): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.get(`${baseUrl}/virtualmachines`);
     }
 
     getVM(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/virtualmachines/${name}`);
     }
 
     getPooledVM(namespace: string, pool: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/virtualmachines?labelSelector=kubevirt.io%2Fvmpool%3D${pool}`);
     }
 
     getVMis(): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.get(`${baseUrl}/virtualmachineinstances`);
     }
 
     getVMi(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/virtualmachineinstances/${name}`);
     }
 
     getVMPools(): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         return this.http.get(`${baseUrl}/virtualmachinepools?labelSelector=kubevirt.io%2Fvmpool`);
     }
 
     getVMPoolsNamespaced(namespace: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/virtualmachinepools`);
     }
 
     getVMPool(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         return this.http.get(`${baseUrl}/namespaces/${namespace}/virtualmachinepools/${name}`);
     }
 
     startVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -64,7 +64,7 @@ export class KubeVirtService {
     }
 
     stopVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -73,7 +73,7 @@ export class KubeVirtService {
     }
 
     powerOffVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -83,7 +83,7 @@ export class KubeVirtService {
     }
 
     restartVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/subresources.kubevirt.io/v1';
+        var baseUrl ='./k8s/apis/subresources.kubevirt.io/v1';
         const headers = {
             'accept': 'application/json'
         };
@@ -91,7 +91,7 @@ export class KubeVirtService {
     }
 
     pauseVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/subresources.kubevirt.io/v1';
+        var baseUrl ='./k8s/apis/subresources.kubevirt.io/v1';
         const headers = {
             'accept': 'application/json'
         };
@@ -99,7 +99,7 @@ export class KubeVirtService {
     }
 
     unpauseVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/subresources.kubevirt.io/v1';
+        var baseUrl ='./k8s/apis/subresources.kubevirt.io/v1';
         const headers = {
             'accept': 'application/json'
         };
@@ -107,7 +107,7 @@ export class KubeVirtService {
     }
 
     scaleVm(namespace: string, name: string, cores: string, threads: string, sockets: string, memory: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -116,7 +116,7 @@ export class KubeVirtService {
     }
 
     changeVmType(namespace: string, name: string, type: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -125,12 +125,12 @@ export class KubeVirtService {
     }
 
     deleteVm(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.delete(`${baseUrl}/namespaces/${namespace}/virtualmachines/${name}`);
     }
 
     createVm(namespace: string, name: string, vmvalue: Object): Observable<any> {
-        var baseUrl ='/k8s/apis/kubevirt.io/v1alpha3';
+        var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -139,22 +139,22 @@ export class KubeVirtService {
     }
 
     getClusterInstanceTypes(): Observable<any> {
-        var baseUrl ='/k8s/apis/instancetype.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/instancetype.kubevirt.io/v1alpha1';
         return this.http.get(`${baseUrl}/virtualmachineclusterinstancetypes`);
     }
 
     getClusterInstanceType(instType: string): Observable<any> {
-        var baseUrl ='/k8s/apis/instancetype.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/instancetype.kubevirt.io/v1alpha1';
         return this.http.get(`${baseUrl}/virtualmachineclusterinstancetypes/${instType}`);
     }
 
     deleteClusterInstanceType(typeName: string): Observable<any> {
-        var baseUrl ='/k8s/apis/instancetype.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/instancetype.kubevirt.io/v1alpha1';
         return this.http.delete(`${baseUrl}/virtualmachineclusterinstancetypes/${typeName}`);
     }
 
     createClusterInstanceType(typeName: string, typeValue: Object): Observable<any> {
-        var baseUrl ='/k8s/apis/instancetype.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/instancetype.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -163,7 +163,7 @@ export class KubeVirtService {
     }
 
     editClusterInstanceType(typeName: string, typeCPU: string, typeMemory: string): Observable<any> {
-        var baseUrl ='/k8s/apis/instancetype.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/instancetype.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -172,7 +172,7 @@ export class KubeVirtService {
     }
 
     startPool(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -181,7 +181,7 @@ export class KubeVirtService {
     }
 
     stopPool(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -190,12 +190,12 @@ export class KubeVirtService {
     }
 
     deletePool(namespace: string, name: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         return this.http.delete(`${baseUrl}/namespaces/${namespace}/virtualmachinepools/${name}`);
     }
 
     scalePoolReplicas(namespace: string, name: string, size: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -204,7 +204,7 @@ export class KubeVirtService {
     }
 
     scalePool(namespace: string, name: string, cores: string, threads: string, sockets: string, memory: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
@@ -213,7 +213,7 @@ export class KubeVirtService {
     }
 
     createPool(namespace: string, name: string, poolvalue: Object): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/json',
             'accept': 'application/json'
@@ -222,7 +222,7 @@ export class KubeVirtService {
     }
 
     changePoolType(namespace: string, name: string, type: string): Observable<any> {
-        var baseUrl ='/k8s/apis/pool.kubevirt.io/v1alpha1';
+        var baseUrl ='./k8s/apis/pool.kubevirt.io/v1alpha1';
         const headers = {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'


### PR DESCRIPTION
Hey, I was playing with your UI and really like the simplicity and cleanliness of it but my typical use-case is actually with clusters that are NATed and managed by Rancher. Here are some changes that allowed me to use the UI even through a reverse proxy/tunnel. 

I also added an image build script for ghcr if you are interested. I used it to help iterate quickly then figured it might be useful to you as well. 

I did test through a local ingress as well and there was no regression that I saw. 