### PR TITLE
Add Live Migration, moved auto-select to the top, fully qualified Network Attachment

### DIFF
--- a/kubernetes/bundled.yaml
+++ b/kubernetes/bundled.yaml
@@ -132,7 +132,7 @@ rules:
     resources: ["network-attachment-definitions"]
     verbs: ["get", "list"]
   - apiGroups: ["kubevirt.io"]
-    resources: ["virtualmachines", "virtualmachineinstances"]
+    resources: ["virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"]
     verbs: ["*"]
   - apiGroups: ["subresources.kubevirt.io"]
     resources: ["*"]

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -47,7 +47,7 @@ rules:
     resources: ["network-attachment-definitions"]
     verbs: ["get", "list"]
   - apiGroups: ["kubevirt.io"]
-    resources: ["virtualmachines", "virtualmachineinstances"]
+    resources: ["virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"]
     verbs: ["*"]
   - apiGroups: ["subresources.kubevirt.io"]
     resources: ["*"]

--- a/src/app/components/vmlist/vmlist.component.html
+++ b/src/app/components/vmlist/vmlist.component.html
@@ -135,6 +135,15 @@
                         <i class="fas fa-redo disabled"></i>
                       </a>
                     </span>
+                    <!--- LIVEMIGRATE BUTTON -->
+                    <span [ngSwitch]="thisVM.running">
+                      <a class="btn" (click)='vmOperations("migrate", thisVM.namespace, thisVM.name)' title="Live Migrate..." *ngSwitchCase="true">
+                        <i class="fas fa-angle-double-right"></i>
+                      </a>
+                      <a class="btn disabled" (click)='vmOperations("migrate", thisVM.namespace, thisVM.name)' title="Live Migrate..." *ngSwitchDefault>
+                        <i class="fas fa-angle-double-right disabled"></i>
+                      </a>
+                    </span>
                      <!--- DELETE BUTTON -->
                      <span [ngSwitch]="thisVM.running">
                       <a class="btn disabled" (click)="showDelete(thisVM.name, thisVM.namespace)" title="Delete..." *ngSwitchCase="true">

--- a/src/app/interfaces/virtual-machine.ts
+++ b/src/app/interfaces/virtual-machine.ts
@@ -19,6 +19,7 @@ export interface VirtualMachine {
                 labels?: {};
             },
             spec: {
+                evictionStrategy?: string,
                 nodeSelector?: {};
                 priorityClassName?: string;
                 domain: {

--- a/src/app/services/kube-virt.service.ts
+++ b/src/app/services/kube-virt.service.ts
@@ -147,7 +147,24 @@ export class KubeVirtService {
         var baseUrl ='./k8s/apis/kubevirt.io/v1alpha3';
         return this.http.delete(`${baseUrl}/namespaces/${namespace}/virtualmachines/${name}`);
     }
-
+    migrateVm(namespace: string, name: string): Observable<any> {
+        var baseUrl ='./k8s/apis/kubevirt.io/v1';
+        const headers = {
+            'content-type': 'application/json',
+            'accept': 'application/json'
+        };
+        return this.http.post(`${baseUrl}/namespaces/${namespace}/virtualmachineinstancemigrations/`, {
+            "apiVersion": "kubevirt.io/v1",
+            "kind": "VirtualMachineInstanceMigration",
+            "metadata": {
+                "name": `${name}-lm-${Date.now()}`,
+                "namespace": namespace
+            },
+            "spec": {
+                "vmiName": name
+            }
+        }, { 'headers': headers } );
+    }
     createVm(virtualMachine: VirtualMachine): Observable<any> {
         var baseUrl ='./k8s/apis/' + virtualMachine.apiVersion;
         let name = virtualMachine.metadata.name;


### PR DESCRIPTION
I added a quick and dirty Live Migration support, fully qualified the `NetworkAttachmentDefinition` in the `VirtualMachine` manifest, added setting `evictionStrategy: LiveMigration` when node is "auto-select" and pushed "auto-select" to the top.

I don't fully know TypeScript/Javascript so this was banged out really quick but it relates to the two issues I created:
https://github.com/kubevirt-manager/kubevirt-manager/issues/88
https://github.com/kubevirt-manager/kubevirt-manager/issues/87

Do what you will with these changes