### PR TITLE
kubernetes: fix trailing whitespace

### DIFF
--- a/kubernetes/bundled.yaml
+++ b/kubernetes/bundled.yaml
@@ -39,7 +39,7 @@ spec:
                 http:
                   type: object
                   properties:
-                    url: 
+                    url:
                       type: string
                 registry:
                   type: object

--- a/kubernetes/crd.yaml
+++ b/kubernetes/crd.yaml
@@ -38,7 +38,7 @@ spec:
                 http:
                   type: object
                   properties:
-                    url: 
+                    url:
                       type: string
                 registry:
                   type: object


### PR DESCRIPTION
Remove extra trailing whitespace