### PR TITLE
fix: typo in VM overview page

### DIFF
--- a/src/app/components/vmdetails/vmdetails.component.html
+++ b/src/app/components/vmdetails/vmdetails.component.html
@@ -97,7 +97,7 @@
                       </a>
                        </dt>
                        <br>
-                       <dd>Run Stragegy: {{activeVm.runStrategy}} </dd>
+                       <dd>Run Strategy: {{activeVm.runStrategy}} </dd>
                        <hr>
                        <dt>Status</dt>
                        <br>


### PR DESCRIPTION
Small typo on the VM Overview Page.