### PR TITLE
Add Helm chart

### DIFF
--- a/charts/.gitignore
+++ b/charts/.gitignore
@@ -1,0 +1,2 @@
+charts/
+Chart.lock

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,6 +1,3 @@
-# Copyright Broadcom, Inc. All Rights Reserved.
-# SPDX-License-Identifier: APACHE-2.0
-
 annotations:
   category: Infrastructure
   licenses: Apache-2.0
@@ -20,9 +17,6 @@ keywords:
   - kubernetes
   - infrastructure
   - virtualization
-maintainers:
-  - name: Broadcom, Inc. All Rights Reserved.
-    url: https://github.com/bitnami/charts
 name: manager
 sources:
   - https://kubevirt-manager.io/get_started.html

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 1.5.1
+appVersion: 1.5.2
 dependencies:
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
@@ -20,4 +20,4 @@ keywords:
 name: manager
 sources:
   - https://kubevirt-manager.io/get_started.html
-version: 1.5.1
+version: 1.5.2

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,29 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+annotations:
+  category: Infrastructure
+  licenses: Apache-2.0
+apiVersion: v2
+appVersion: 1.5.1
+dependencies:
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    tags:
+      - bitnami-common
+    version: 2.x.x
+description: Create, Manage and Operate your KubeVirt Workloads in a simple, effective and friendly Web User Interface.
+home: https://kubevirt-manager.io/
+icon: https://kubevirt-manager.io/img/logo-website.png
+keywords:
+  - kubevirt
+  - kubernetes
+  - infrastructure
+  - virtualization
+maintainers:
+  - name: Broadcom, Inc. All Rights Reserved.
+    url: https://github.com/bitnami/charts
+name: manager
+sources:
+  - https://kubevirt-manager.io/get_started.html
+version: 1.5.1

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,6 +1,6 @@
 <!--- app-name: kubevirt-manager -->
 
-# Bitnami package for kubevirt-manager
+# helm package for kubevirt-manager
 
 The kubevirt-manager controls and manages disks, so a StorageClass is required for the solution to function properly.
 
@@ -17,21 +17,15 @@ volumeBindingMode: WaitForFirstConsumer
 
 [Overview of kubevirt-manager](https://kubevirt-manager.io/)
 
-Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-
 ## TL;DR
 
 ```console
-helm install my-release oci://registry-1.docker.io/bitnamicharts/kubevirt-manager
+helm install my-release https://kubevirt-manager.io/charts
 ```
-
-
 
 ## Introduction
 
-Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
-
-This chart bootstraps [kubevirt-manager](https://github.com/bitnami/containers/tree/main/bitnami/kubevirt-manager) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+This chart bootstraps [kubevirt-manager](https://kubevirt-manager.io) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
 
 
 ## Prerequisites
@@ -44,79 +38,10 @@ This chart bootstraps [kubevirt-manager](https://github.com/bitnami/containers/t
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://REGISTRY_NAME/REPOSITORY_NAME/kubevirt-manager
+helm install my-release https://kubevirt-manager.io/charts
 ```
-
-> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
 
 The command deploys kubevirt-manager on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
-
-## Configuration and installation details
-
-### Resource requests and limits
-
-Bitnami charts allow setting resource requests and limits for all containers inside the chart deployment. These are inside the `resources` value (check parameter table). Setting requests is essential for production workloads and these should be adapted to your specific use case.
-
-To make this process easier, the chart contains the `resourcesPreset` values, which automatically sets the `resources` section according to different presets. Check these presets in [the bitnami/common chart](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15). However, in production workloads using `resourcesPreset` is discouraged as it may not fully adapt to your specific needs. Find more information on container resource management in the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
-
-### [Rolling vs Immutable tags](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html)
-
-It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
-
-Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
-
-### Backup and restore
-
-To back up and restore Helm chart deployments on Kubernetes, you need to back up the persistent volumes from the source deployment and attach them to a new deployment using [Velero](https://velero.io/), a Kubernetes backup/restore tool. Find the instructions for using Velero in [this guide](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-backup-restore-deployments-velero-index.html).
-
-### Use Sidecars and Init Containers
-
-If additional containers are needed in the same pod (such as additional metrics or logging exporters), they can be defined using the `sidecars` config parameter.
-
-```yaml
-sidecars:
-- name: your-image-name
-  image: your-image
-  imagePullPolicy: Always
-  ports:
-  - name: portname
-    containerPort: 1234
-```
-
-If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter (where available), as shown in the example below:
-
-```yaml
-service:
-  extraPorts:
-  - name: extraPort
-    port: 11311
-    targetPort: 11311
-```
-
-
-If additional init containers are needed in the same pod, they can be defined using the `initContainers` parameter. Here is an example:
-
-```yaml
-initContainers:
-  - name: your-image-name
-    image: your-image
-    imagePullPolicy: Always
-    ports:
-      - name: portname
-        containerPort: 1234
-```
-
-> NOTE: This Helm chart already includes initContainers to copy a file from a read-only config volume to a writable persistent volume so the main kubevirt-manager container can use or modify it.
-
-Learn more about [sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/) and [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
-
-### Set Pod affinity
-
-This chart allows you to set custom Pod affinity using the `affinity` parameter. Find more information about Pod's affinity in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
-
-As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/main/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
-
-
 
 ## Parameters
 
@@ -353,30 +278,10 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ...
 
-> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```console
-helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/kubevirt-manager
+helm install my-release -f values.yaml https://kubevirt-manager.io/charts
 ```
-
-> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
-> **Tip**: You can use the default [values.yaml](https://github.com/bitnami/charts/tree/main/bitnami/kubevirt-manager/values.yaml)
-
-## License
-
-Copyright &copy; 2025 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-<http://www.apache.org/licenses/LICENSE-2.0>
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,382 @@
+<!--- app-name: kubevirt-manager -->
+
+# Bitnami package for kubevirt-manager
+
+The kubevirt-manager controls and manages disks, so a StorageClass is required for the solution to function properly.
+
+Ensure the allowVolumeExpansion feature is enabled on the StorageClass you intend to use:
+
+```yaml
+allowVolumeExpansion: true
+```
+If you are using hostpath-provisioner or some local storage you may also need:
+
+```yaml
+volumeBindingMode: WaitForFirstConsumer
+```
+
+[Overview of kubevirt-manager](https://kubevirt-manager.io/)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+
+## TL;DR
+
+```console
+helm install my-release oci://registry-1.docker.io/bitnamicharts/kubevirt-manager
+```
+
+
+
+## Introduction
+
+Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
+
+This chart bootstraps [kubevirt-manager](https://github.com/bitnami/containers/tree/main/bitnami/kubevirt-manager) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.8.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release oci://REGISTRY_NAME/REPOSITORY_NAME/kubevirt-manager
+```
+
+> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
+
+The command deploys kubevirt-manager on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
+
+## Configuration and installation details
+
+### Resource requests and limits
+
+Bitnami charts allow setting resource requests and limits for all containers inside the chart deployment. These are inside the `resources` value (check parameter table). Setting requests is essential for production workloads and these should be adapted to your specific use case.
+
+To make this process easier, the chart contains the `resourcesPreset` values, which automatically sets the `resources` section according to different presets. Check these presets in [the bitnami/common chart](https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15). However, in production workloads using `resourcesPreset` is discouraged as it may not fully adapt to your specific needs. Find more information on container resource management in the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+
+### [Rolling vs Immutable tags](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Backup and restore
+
+To back up and restore Helm chart deployments on Kubernetes, you need to back up the persistent volumes from the source deployment and attach them to a new deployment using [Velero](https://velero.io/), a Kubernetes backup/restore tool. Find the instructions for using Velero in [this guide](https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-backup-restore-deployments-velero-index.html).
+
+### Use Sidecars and Init Containers
+
+If additional containers are needed in the same pod (such as additional metrics or logging exporters), they can be defined using the `sidecars` config parameter.
+
+```yaml
+sidecars:
+- name: your-image-name
+  image: your-image
+  imagePullPolicy: Always
+  ports:
+  - name: portname
+    containerPort: 1234
+```
+
+If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter (where available), as shown in the example below:
+
+```yaml
+service:
+  extraPorts:
+  - name: extraPort
+    port: 11311
+    targetPort: 11311
+```
+
+
+If additional init containers are needed in the same pod, they can be defined using the `initContainers` parameter. Here is an example:
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
+
+> NOTE: This Helm chart already includes initContainers to copy a file from a read-only config volume to a writable persistent volume so the main kubevirt-manager container can use or modify it.
+
+Learn more about [sidecar containers](https://kubernetes.io/docs/concepts/workloads/pods/) and [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
+
+### Set Pod affinity
+
+This chart allows you to set custom Pod affinity using the `affinity` parameter. Find more information about Pod's affinity in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/main/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+
+
+## Parameters
+
+### Global parameters
+
+| Name                                                  | Description                                                                                                                                                                                                                                                                                                                                                         | Value   |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `global.imageRegistry`                                | Global Docker image registry                                                                                                                                                                                                                                                                                                                                        | `""`    |
+| `global.imagePullSecrets`                             | Global Docker registry secret names as an array                                                                                                                                                                                                                                                                                                                     | `[]`    |
+| `global.defaultStorageClass`                          | Global default StorageClass for Persistent Volume(s)                                                                                                                                                                                                                                                                                                                | `""`    |
+| `global.security.allowInsecureImages`                 | Allows skipping image verification                                                                                                                                                                                                                                                                                                                                  | `false` |
+| `global.compatibility.openshift.adaptSecurityContext` | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation) | `auto`  |
+| `global.compatibility.omitEmptySeLinuxOptions`        | If set to true, removes the seLinuxOptions from the securityContexts when it is set to an empty object                                                                                                                                                                                                                                                              | `false` |
+
+### Common parameters
+
+| Name                     | Description                                                                             | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `apiVersions`            | Override Kubernetes API versions reported by .Capabilities                              | `[]`            |
+| `nameOverride`           | String to partially override common.names.name                                          | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the chart release                                 | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the chart release                                    | `["infinity"]`  |
+
+### manager Parameters
+
+| Name                                                        | Description                                                                                                                                                                                                                        | Value                             |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `manager.image.registry`                                    | manager image registry                                                                                                                                                                                                             | `REGISTRY_NAME`                   |
+| `manager.image.repository`                                  | manager image repository                                                                                                                                                                                                           | `REPOSITORY_NAME/kubevirtmanager` |
+| `manager.image.digest`                                      | manager image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)                                                                                 | `""`                              |
+| `manager.image.pullPolicy`                                  | manager image pull policy                                                                                                                                                                                                          | `IfNotPresent`                    |
+| `manager.image.pullSecrets`                                 | manager image pull secrets                                                                                                                                                                                                         | `[]`                              |
+| `manager.image.debug`                                       | Enable manager image debug mode                                                                                                                                                                                                    | `false`                           |
+| `manager.replicaCount`                                      | Number of manager replicas to deploy                                                                                                                                                                                               | `1`                               |
+| `manager.containerPorts.http`                               | manager HTTP container port                                                                                                                                                                                                        | `8080`                            |
+| `manager.extraContainerPorts`                               | Optionally specify extra list of additional ports for manager containers                                                                                                                                                           | `[]`                              |
+| `manager.livenessProbe.enabled`                             | Enable livenessProbe on manager containers                                                                                                                                                                                         | `false`                           |
+| `manager.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                                                                                                                            | `90`                              |
+| `manager.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                                                                                                                                   | `10`                              |
+| `manager.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                                                                                                                                                  | `5`                               |
+| `manager.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                                                                                                                                                | `1`                               |
+| `manager.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                                                                                                                                                | `5`                               |
+| `manager.readinessProbe.enabled`                            | Enable readinessProbe on manager containers                                                                                                                                                                                        | `false`                           |
+| `manager.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                                                                                                                                           | `90`                              |
+| `manager.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                                                                                                                                                  | `10`                              |
+| `manager.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                                                                                                                                                 | `5`                               |
+| `manager.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                                                                                                                                               | `1`                               |
+| `manager.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                                                                                                                                               | `5`                               |
+| `manager.startupProbe.enabled`                              | Enable startupProbe on manager containers                                                                                                                                                                                          | `false`                           |
+| `manager.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                                                                                                                                             | `90`                              |
+| `manager.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                                                                                                                                                    | `10`                              |
+| `manager.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                                                                                                                                                   | `5`                               |
+| `manager.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                                                                                                                                 | `1`                               |
+| `manager.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                                                                                                                                 | `5`                               |
+| `manager.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                                                                                                                                                | `{}`                              |
+| `manager.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                                                                                                                                               | `{}`                              |
+| `manager.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                                                                                                                                 | `{}`                              |
+| `manager.resourcesPreset`                                   | Set manager container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if manager.resources is set (manager.resources is recommended for production). | `nano`                            |
+| `manager.resources`                                         | Set manager container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                                          | `{}`                              |
+| `manager.podSecurityContext.enabled`                        | Enable manager pods' Security Context                                                                                                                                                                                              | `true`                            |
+| `manager.podSecurityContext.fsGroupChangePolicy`            | Set filesystem group change policy for manager pods                                                                                                                                                                                | `Always`                          |
+| `manager.podSecurityContext.sysctls`                        | Set kernel settings using the sysctl interface for manager pods                                                                                                                                                                    | `[]`                              |
+| `manager.podSecurityContext.supplementalGroups`             | Set filesystem extra groups for manager pods                                                                                                                                                                                       | `[]`                              |
+| `manager.podSecurityContext.fsGroup`                        | Set fsGroup in manager pods' Security Context                                                                                                                                                                                      | `1001`                            |
+| `manager.containerSecurityContext.enabled`                  | Enabled manager container' Security Context                                                                                                                                                                                        | `true`                            |
+| `manager.containerSecurityContext.seLinuxOptions`           | Set SELinux options in manager container                                                                                                                                                                                           | `undefined`                       |
+| `manager.containerSecurityContext.runAsUser`                | Set runAsUser in manager container' Security Context                                                                                                                                                                               | `10000`                           |
+| `manager.containerSecurityContext.readOnlyRootFilesystem`   | Set readOnlyRootFilesystem in manager container' Security Context                                                                                                                                                                  | `true`                            |
+| `manager.containerSecurityContext.allowPrivilegeEscalation` | Set allowPrivilegeEscalation in manager container' Security Context                                                                                                                                                                | `false`                           |
+| `manager.containerSecurityContext.runAsGroup`               | Set runAsGroup in manager container' Security Context                                                                                                                                                                              | `30000`                           |
+| `manager.existingConfigmap`                                 | The name of an existing ConfigMap with your custom configuration for manager                                                                                                                                                       | `nil`                             |
+| `manager.command`                                           | Override default manager container command (useful when using custom images)                                                                                                                                                       | `[]`                              |
+| `manager.args`                                              | Override default manager container args (useful when using custom images)                                                                                                                                                          | `[]`                              |
+| `manager.automountServiceAccountToken`                      | Mount Service Account token in manager pods                                                                                                                                                                                        | `false`                           |
+| `manager.hostAliases`                                       | manager pods host aliases                                                                                                                                                                                                          | `[]`                              |
+| `manager.daemonsetAnnotations`                              | Annotations for manager daemonset                                                                                                                                                                                                  | `{}`                              |
+| `manager.deploymentAnnotations`                             | Annotations for manager deployment                                                                                                                                                                                                 | `{}`                              |
+| `manager.statefulsetAnnotations`                            | Annotations for manager statefulset                                                                                                                                                                                                | `{}`                              |
+| `manager.podLabels`                                         | Extra labels for manager pods                                                                                                                                                                                                      | `{}`                              |
+| `manager.podAnnotations`                                    | Annotations for manager pods                                                                                                                                                                                                       | `{}`                              |
+| `manager.podAffinityPreset`                                 | Pod affinity preset. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`                                                                                                                                        | `""`                              |
+| `manager.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`                                                                                                                                   | `""`                              |
+| `manager.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`                                                                                                                                  | `""`                              |
+| `manager.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `manager.affinity` is set                                                                                                                                                                      | `""`                              |
+| `manager.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `manager.affinity` is set                                                                                                                                                                   | `[]`                              |
+| `manager.affinity`                                          | Affinity for manager pods assignment                                                                                                                                                                                               | `{}`                              |
+| `manager.nodeSelector`                                      | Node labels for manager pods assignment                                                                                                                                                                                            | `{}`                              |
+| `manager.tolerations`                                       | Tolerations for manager pods assignment                                                                                                                                                                                            | `[]`                              |
+| `manager.updateStrategy.type`                               | manager deployment strategy type                                                                                                                                                                                                   | `Recreate`                        |
+| `manager.updateStrategy.type`                               | manager statefulset strategy type                                                                                                                                                                                                  | `Recreate`                        |
+| `manager.podManagementPolicy`                               | Pod management policy for manager statefulset                                                                                                                                                                                      | `OrderedReady`                    |
+| `manager.priorityClassName`                                 | manager pods' priorityClassName                                                                                                                                                                                                    | `""`                              |
+| `manager.topologySpreadConstraints`                         | Topology Spread Constraints for manager pod assignment spread across your cluster among failure-domains                                                                                                                            | `[]`                              |
+| `manager.schedulerName`                                     | Name of the k8s scheduler (other than default) for manager pods                                                                                                                                                                    | `""`                              |
+| `manager.terminationGracePeriodSeconds`                     | Seconds manager pods need to terminate gracefully                                                                                                                                                                                  | `""`                              |
+| `manager.lifecycleHooks`                                    | for manager containers to automate configuration before or after startup                                                                                                                                                           | `{}`                              |
+| `manager.extraEnvVars`                                      | Array with extra environment variables to add to manager containers                                                                                                                                                                | `[]`                              |
+| `manager.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for manager containers                                                                                                                                                        | `""`                              |
+| `manager.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for manager containers                                                                                                                                                           | `""`                              |
+| `manager.extraVolumes`                                      | Optionally specify extra list of additional volumes for the manager pods                                                                                                                                                           | `[]`                              |
+| `manager.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the manager containers                                                                                                                                                | `[]`                              |
+| `manager.sidecars`                                          | Add additional sidecar containers to the manager pods                                                                                                                                                                              | `[]`                              |
+| `manager.initContainers`                                    | Add additional init containers to the manager pods                                                                                                                                                                                 | `[]`                              |
+| `manager.pdb.create`                                        | Enable/disable a Pod Disruption Budget creation                                                                                                                                                                                    | `true`                            |
+| `manager.pdb.minAvailable`                                  | Minimum number/percentage of pods that should remain scheduled                                                                                                                                                                     | `""`                              |
+| `manager.pdb.maxUnavailable`                                | Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `manager.pdb.minAvailable` and `manager.pdb.maxUnavailable` are empty.                                                                     | `""`                              |
+| `manager.autoscaling.vpa.enabled`                           | Enable VPA for manager pods                                                                                                                                                                                                        | `false`                           |
+| `manager.autoscaling.vpa.annotations`                       | Annotations for VPA resource                                                                                                                                                                                                       | `{}`                              |
+| `manager.autoscaling.vpa.controlledResources`               | VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory                                                                                                                                     | `[]`                              |
+| `manager.autoscaling.vpa.maxAllowed`                        | VPA Max allowed resources for the pod                                                                                                                                                                                              | `{}`                              |
+| `manager.autoscaling.vpa.minAllowed`                        | VPA Min allowed resources for the pod                                                                                                                                                                                              | `{}`                              |
+| `manager.autoscaling.vpa.updatePolicy.updateMode`           | Autoscaling update policy                                                                                                                                                                                                          | `Auto`                            |
+| `manager.autoscaling.hpa.enabled`                           | Enable HPA for manager pods                                                                                                                                                                                                        | `false`                           |
+| `manager.autoscaling.hpa.minReplicas`                       | Minimum number of replicas                                                                                                                                                                                                         | `""`                              |
+| `manager.autoscaling.hpa.maxReplicas`                       | Maximum number of replicas                                                                                                                                                                                                         | `""`                              |
+| `manager.autoscaling.hpa.targetCPU`                         | Target CPU utilization percentage                                                                                                                                                                                                  | `""`                              |
+| `manager.autoscaling.hpa.targetMemory`                      | Target Memory utilization percentage                                                                                                                                                                                               | `""`                              |
+
+### Traffic Exposure Parameters
+
+| Name                                    | Description                                                                                                                      | Value                    |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                          | manager service type                                                                                                             | `ClusterIP`              |
+| `service.ports.http`                    | manager service HTTP port                                                                                                        | `8080`                   |
+| `service.nodePorts.http`                | Node port for HTTP                                                                                                               | `""`                     |
+| `service.clusterIP`                     | manager service Cluster IP                                                                                                       | `""`                     |
+| `service.loadBalancerIP`                | manager service Load Balancer IP                                                                                                 | `""`                     |
+| `service.loadBalancerSourceRanges`      | manager service Load Balancer sources                                                                                            | `[]`                     |
+| `service.annotations`                   | Additional custom annotations for manager service                                                                                | `{}`                     |
+| `service.extraPorts`                    | Extra ports to expose in manager service (normally used with the `sidecars` value)                                               | `[]`                     |
+| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `networkPolicy.enabled`                 | Specifies whether a NetworkPolicy should be created                                                                              | `true`                   |
+| `networkPolicy.allowExternal`           | Don't require server label for connections                                                                                       | `true`                   |
+| `networkPolicy.allowExternalEgress`     | Allow the pod to access any range of port and all destinations.                                                                  | `true`                   |
+| `networkPolicy.addExternalClientAccess` | Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.                        | `true`                   |
+| `networkPolicy.extraIngress`            | Add extra ingress rules to the NetworkPolicy                                                                                     | `[]`                     |
+| `networkPolicy.extraEgress`             | Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)                                               | `[]`                     |
+| `networkPolicy.ingressPodMatchLabels`   | Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.                              | `{}`                     |
+| `networkPolicy.ingressNSMatchLabels`    | Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                        | `{}`                     |
+| `networkPolicy.ingressNSPodMatchLabels` | Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.                    | `{}`                     |
+| `ingress.enabled`                       | Enable ingress record generation for manager                                                                                     | `false`                  |
+| `ingress.pathType`                      | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`                    | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.hostname`                      | Default host for the ingress record                                                                                              | `manager.local`          |
+| `ingress.ingressClassName`              | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `ingress.path`                          | Default path for the ingress record                                                                                              | `/`                      |
+| `ingress.annotations`                   | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                           | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`                    | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`                    | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `ingress.extraPaths`                    | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
+| `ingress.extraTls`                      | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
+| `ingress.secrets`                       | Custom TLS certificates as secrets                                                                                               | `[]`                     |
+| `ingress.extraRules`                    | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
+
+### Persistence Parameters
+
+| Name                        | Description                                                                                             | Value               |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `true`              |
+| `persistence.mountPath`     | Path to mount the volume at.                                                                            | `/var/cache/nginx`  |
+| `persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
+| `persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |
+| `persistence.annotations`   | Persistent Volume Claim annotations                                                                     | `{}`                |
+| `persistence.accessModes`   | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
+| `persistence.size`          | Size of data volume                                                                                     | `8Gi`               |
+| `persistence.existingClaim` | The name of an existing PVC to use for persistence                                                      | `""`                |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                  | `{}`                |
+| `persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
+
+### Init Container Parameters
+
+| Name                                                        | Description                                                                                                                                                                                                                                         | Value                      |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `volumePermissions.enabled`                                 | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`                                                                                                                                                     | `false`                    |
+| `volumePermissions.image.registry`                          | OS Shell + Utility image registry                                                                                                                                                                                                                   | `REGISTRY_NAME`            |
+| `volumePermissions.image.repository`                        | OS Shell + Utility image repository                                                                                                                                                                                                                 | `REPOSITORY_NAME/os-shell` |
+| `volumePermissions.image.pullPolicy`                        | OS Shell + Utility image pull policy                                                                                                                                                                                                                | `IfNotPresent`             |
+| `volumePermissions.image.pullSecrets`                       | OS Shell + Utility image pull secrets                                                                                                                                                                                                               | `[]`                       |
+| `volumePermissions.resourcesPreset`                         | Set init container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production). | `nano`                     |
+| `volumePermissions.resources`                               | Set init container requests and limits for different resources like CPU or memory (essential for production workloads)                                                                                                                              | `{}`                       |
+| `volumePermissions.containerSecurityContext.enabled`        | Enabled init container' Security Context                                                                                                                                                                                                            | `true`                     |
+| `volumePermissions.containerSecurityContext.seLinuxOptions` | Set SELinux options in init container                                                                                                                                                                                                               | `{}`                       |
+| `volumePermissions.containerSecurityContext.runAsUser`      | Set init container's Security Context runAsUser                                                                                                                                                                                                     | `0`                        |
+
+### Other Parameters
+
+| Name                                          | Description                                                                                            | Value                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `rbac.role.create`                            | Specifies whether a Role should be created                                                             | `false`                                                      |
+| `rbac.role.rules`                             | Custom RBAC rules to set                                                                               | `""`                                                         |
+| `rbac.clusterrole1.create`                    | Specifies whether a ClusterRole1 should be created                                                     | `true`                                                       |
+| `rbac.clusterrole1.rules`                     | Custom RBAC rules to set                                                                               | `[]`                                                         |
+| `rbac.clusterrole2.create`                    | Specifies whether a ClusterRole2 should be created                                                     | `true`                                                       |
+| `rbac.clusterrole2.rules`                     | Custom RBAC rules to set                                                                               | `[]`                                                         |
+| `rbac.clusterrole3.create`                    | Specifies whether a ClusterRole3 should be created                                                     | `true`                                                       |
+| `rbac.clusterrole3.rules`                     | Custom RBAC rules to set                                                                               | `[]`                                                         |
+| `rbac.clusterrole4.create`                    | Specifies whether a ClusterRole4 should be created                                                     | `true`                                                       |
+| `rbac.clusterrole4.rules`                     | Custom RBAC rules to set                                                                               | `[]`                                                         |
+| `priorityClass1.enabled`                      | Enable a PriorityClass1 to control the scheduling priority of operator pods                            | `true`                                                       |
+| `priorityClass1.name`                         | The name of the PriorityClass1 to use                                                                  | `vm-standard`                                                |
+| `priorityClass1.value`                        | The value of the PriorityClass1 to use                                                                 | `999999999`                                                  |
+| `priorityClass1.description`                  | The description of the PriorityClass1 to use                                                           | `Priority class for VMs which should not be preemtited.`     |
+| `priorityClass1.preemptionPolicy`             | controls the preemption behavior for the pod.                                                          | `Never`                                                      |
+| `priorityClass2.enabled`                      | Enable a PriorityClass2 to control the scheduling priority of operator pods                            | `true`                                                       |
+| `priorityClass2.name`                         | The name of the PriorityClass2 to use                                                                  | `vm-preemptible`                                             |
+| `priorityClass2.value`                        | The value of the PriorityClass2 to use                                                                 | `1000000`                                                    |
+| `priorityClass2.description`                  | The description of the PriorityClass2 to use                                                           | `Priority class for VMs which are allowed to be preemtited.` |
+| `priorityClass2.preemptionPolicy`             | controls the preemption behavior for the pod.                                                          | `PreemptLowerPriority`                                       |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                   | `true`                                                       |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                 | `kubevirt-manager`                                           |
+| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template)                                       | `{}`                                                         |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                         | `""`                                                         |
+| `metrics.enabled`                             | Enable the export of Prometheus metrics                                                                | `false`                                                      |
+| `metrics.serviceMonitor.enabled`              | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                                                      |
+| `metrics.serviceMonitor.namespace`            | Namespace in which Prometheus is running                                                               | `""`                                                         |
+| `metrics.serviceMonitor.annotations`          | Additional custom annotations for the ServiceMonitor                                                   | `{}`                                                         |
+| `metrics.serviceMonitor.labels`               | Extra labels for the ServiceMonitor                                                                    | `{}`                                                         |
+| `metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in Prometheus                       | `""`                                                         |
+| `metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                               | `false`                                                      |
+| `metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped.                                                           | `""`                                                         |
+| `metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                                | `""`                                                         |
+| `metrics.serviceMonitor.metricRelabelings`    | Specify additional relabeling of metrics                                                               | `[]`                                                         |
+| `metrics.serviceMonitor.relabelings`          | Specify general relabeling                                                                             | `[]`                                                         |
+| `metrics.serviceMonitor.selector`             | Prometheus instance selector labels                                                                    | `{}`                                                         |
+
+...
+
+> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml oci://REGISTRY_NAME/REPOSITORY_NAME/kubevirt-manager
+```
+
+> Note: You need to substitute the placeholders `REGISTRY_NAME` and `REPOSITORY_NAME` with a reference to your Helm chart registry and repository. For example, in the case of Bitnami, you need to use `REGISTRY_NAME=registry-1.docker.io` and `REPOSITORY_NAME=bitnamicharts`.
+> **Tip**: You can use the default [values.yaml](https://github.com/bitnami/charts/tree/main/bitnami/kubevirt-manager/values.yaml)
+
+## License
+
+Copyright &copy; 2025 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/charts/crds/kubevirt-manager.yaml
+++ b/charts/crds/kubevirt-manager.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: images.kubevirt-manager.io
+spec:
+  group: kubevirt-manager.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-validations:
+                - rule: "self.type.matches('^(http)|(gcs)|(s3)|(registry)|(pvc)$')"
+                  message: "spec.type should be: http, registry, s3, gcs, pvc"
+              required:
+                - type
+                - readableName
+              oneOf:
+                - required: ["http"]
+                - required: ["registry"]
+                - required: ["s3"]
+                - required: ["gcs"]
+                - required: ["pvc"]
+              properties:
+                type:
+                  type: string
+                credentials:
+                  type: string
+                readableName:
+                  type: string
+                readableDescription:
+                  type: string
+                http:
+                  type: object
+                  properties:
+                    url: 
+                      type: string
+                registry:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                s3:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                gcs:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                pvc:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+      additionalPrinterColumns:
+        - name: "Type"
+          type: "string"
+          jsonPath: ".spec.type"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+  scope: Namespaced
+  names:
+    plural: images
+    singular: image
+    kind: Image
+    shortNames:
+      - img

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,26 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami for more information.
+
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.diagnosticMode.enabled }}
+The chart has been deployed in diagnostic mode. All probes have been disabled and the command has been overwritten with:
+
+  command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 4 }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 4 }}
+
+Get the list of pods by executing:
+
+  kubectl get pods --namespace {{ include "common.names.namespace" . | quote }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Access the pod you want to debug by executing
+
+  kubectl exec --namespace {{ include "common.names.namespace" . | quote }} -ti <NAME OF THE POD> -- bash
+
+{{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.manager.image }}
+

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -2,8 +2,6 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
-Did you know there are enterprise versions of the Bitnami catalog? For enhanced secure software supply chain features, unlimited pulls from Docker, LTS support, or application customization, see Bitnami Premium or Tanzu Application Catalog. See https://www.arrow.com/globalecs/na/vendors/bitnami for more information.
-
 ** Please be patient while the chart is being deployed **
 
 {{- if .Values.diagnosticMode.enabled }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,9 +1,4 @@
 {{/*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
-{{/*
 Return the proper manager image name
 */}}
 {{- define "manager.image" -}}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/*
+Return the proper manager image name
+*/}}
+{{- define "manager.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.manager.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "manager.volumePermissions.image" -}}
+{{- include "common.images.image" ( dict "imageRoot" .Values.volumePermissions.image "global" .Values.global ) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "manager.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.manager.image  .Values.volumePermissions.image) "context" $) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if cert-manager required annotations for TLS signed certificates are set in the Ingress annotations
+Ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+*/}}
+{{- define "manager.ingress.certManagerRequest" -}}
+{{ if or (hasKey . "cert-manager.io/cluster-issuer") (hasKey . "cert-manager.io/issuer") }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message.
+*/}}
+{{- define "manager.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "manager.validateValues.foo" .) -}}
+{{- $messages := append $messages (include "manager.validateValues.bar" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- end -}}
+{{- end -}}

--- a/charts/templates/clusterrole-kubevirt-manager-cas-management.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-cas-management.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{ if .Values.rbac.clusterrole4.create }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole

--- a/charts/templates/clusterrole-kubevirt-manager-cas-management.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-cas-management.yaml
@@ -1,0 +1,26 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{ if .Values.rbac.clusterrole4.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: kubevirt-manager-cas-management
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["machinedeployments", "machinedeployments/scale", "machines", "machinesets", "machinepools"]
+    verbs: ["get", "list", "watch", "udate"]
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["kubevirtcluster", "kubevirtmachinetemplate", "kubevirtmachinetemplates"]
+    verbs: ["get", "list", "watch", "udate"]
+  {{- if .Values.rbac.clusterrole4.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.clusterrole4.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/templates/clusterrole-kubevirt-manager-cas-workload.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-cas-workload.yaml
@@ -1,0 +1,51 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{ if .Values.rbac.clusterrole3.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: kubevirt-manager-cas-workload
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "persistentvolumeclaims", "persistentvolumes", "pods", "replicationcontrollers", "services", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "udate"]
+  - apiGroups: [""]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes", "storageclasses", "csidrivers", "csistoragecapacities"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "replicasets", "statefulsets"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]
+  {{- if .Values.rbac.clusterrole3.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.clusterrole3.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}
+

--- a/charts/templates/clusterrole-kubevirt-manager-cas-workload.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-cas-workload.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{ if .Values.rbac.clusterrole3.create }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole

--- a/charts/templates/clusterrole-kubevirt-manager-kccm.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-kccm.yaml
@@ -1,0 +1,32 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{ if .Values.rbac.clusterrole2.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: kubevirt-manager-kccm
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachineinstances"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["*"]
+  {{- if .Values.rbac.clusterrole2.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.clusterrole2.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/templates/clusterrole-kubevirt-manager-kccm.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager-kccm.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{ if .Values.rbac.clusterrole2.create }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole

--- a/charts/templates/clusterrole-kubevirt-manager.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager.yaml
@@ -1,0 +1,92 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{ if .Values.rbac.clusterrole1.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: kubevirt-manager
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "persistentvolumes", "services", "secrets", "serviceaccounts", "configmaps"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["*"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["role", "clusterrole"]
+    verbs: ["get", "list"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "clusterrolebindings"]
+    verbs: ["*"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources: ["network-attachment-definitions"]
+    verbs: ["get", "list"]
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachines", "virtualmachineinstances", "virtualmachineinstancemigrations"]
+    verbs: ["*"]
+  - apiGroups: ["subresources.kubevirt.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "update", "patch"]
+  - apiGroups: ["instancetype.kubevirt.io"]
+    resources: ["*"]
+    verbs: ["*"] 
+  - apiGroups: ["cdi.kubevirt.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["pool.kubevirt.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["scheduling.k8s.io"]
+    resources: ["priorityclasses"]
+    verbs: ["get", "list"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["*"]
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["clusters", "machinedeployments"]
+    verbs: ["*"]
+  - apiGroups: ["controlplane.cluster.x-k8s.io"]
+    resources: ["kubeadmcontrolplanes"]
+    verbs: ["*"]
+  - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+    resources: ["kubevirtmachinetemplates", "kubevirtclusters"]
+    verbs: ["*"]
+  - apiGroups: ["bootstrap.cluster.x-k8s.io"]
+    resources: ["kubeadmconfigtemplates"]
+    verbs: ["*"]
+  - apiGroups: ["addons.cluster.x-k8s.io"]
+    resources: ["clusterresourcesets"]
+    verbs: ["*"]
+  - apiGroups: ["kubevirt-manager.io"]
+    resources: ["images"]
+    verbs: ["*"]
+  {{- if .Values.rbac.clusterrole1.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.rbac.clusterrole1.rules "context" $ ) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/templates/clusterrole-kubevirt-manager.yaml
+++ b/charts/templates/clusterrole-kubevirt-manager.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{ if .Values.rbac.clusterrole1.create }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole

--- a/charts/templates/clusterrolebinding-kubevirt-manager-cas-management.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-cas-management.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/templates/clusterrolebinding-kubevirt-manager-cas-management.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-cas-management.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-manager-cas-management
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt-manager-cas-management
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "manager.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/charts/templates/clusterrolebinding-kubevirt-manager-cas-workload.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-cas-workload.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-manager-cas-workload
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt-manager-cas-workload
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "manager.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/charts/templates/clusterrolebinding-kubevirt-manager-cas-workload.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-cas-workload.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/templates/clusterrolebinding-kubevirt-manager-kccm.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-kccm.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/templates/clusterrolebinding-kubevirt-manager-kccm.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager-kccm.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-manager-kccm
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt-manager-kccm
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "manager.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/charts/templates/clusterrolebinding-kubevirt-manager.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:

--- a/charts/templates/clusterrolebinding-kubevirt-manager.yaml
+++ b/charts/templates/clusterrolebinding-kubevirt-manager.yaml
@@ -1,0 +1,24 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-manager
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "manager.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -1,0 +1,174 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if or .Values.manager.deploymentAnnotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.manager.deploymentAnnotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.manager.autoscaling.hpa.enabled }}
+  replicas: {{ .Values.manager.replicaCount }}
+  {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.manager.podLabels .Values.commonLabels) "context" .) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+      app.kubernetes.io/component: manager
+      app: kubevirt-manager
+      kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if .Values.manager.updateStrategy }}
+  strategy: {{- toYaml .Values.manager.updateStrategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- if .Values.manager.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.manager.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+        app.kubernetes.io/component: manager
+        app: kubevirt-manager
+        kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+    spec:
+      {{- include "manager.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.manager.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.manager.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.manager.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.manager.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.manager.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.manager.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.manager.priorityClassName }}
+      priorityClassName: {{ .Values.manager.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.manager.schedulerName }}
+      schedulerName: {{ .Values.manager.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.manager.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.manager.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.manager.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if or (and .Values.volumePermissions.enabled .Values.persistence.enabled) .Values.manager.initContainers }}
+      initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}
+        - name: volume-permissions
+          image: {{ include "manager.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+          {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.volumePermissions.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.volumePermissions.resources }}
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          {{- else if ne .Values.volumePermissions.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.volumePermissions.resourcesPreset) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+        {{- end }}
+        {{- if .Values.manager.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.manager.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: kubevirtmgr
+          image: {{ template "manager.image" . }}
+          imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.manager.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.manager.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.manager.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.manager.args "context" $) | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.manager.containerPorts.http }}
+            {{- if .Values.manager.extraContainerPorts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.manager.extraContainerPorts "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if .Values.manager.containerSecurityContext.enabled }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.manager.containerSecurityContext "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.manager.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.manager.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.manager.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.manager.livenessProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.manager.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.manager.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.manager.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.manager.readinessProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.manager.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.manager.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.manager.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.manager.startupProbe "enabled") "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.manager.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.manager.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: cache-volume
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+            - name: run-volume
+              mountPath: /var/run
+            - name: auth-config
+              mountPath: /etc/nginx/auth.d/
+            - name: auth-secret
+              mountPath: /etc/nginx/secret.d/
+            - name: prometheus-config
+              mountPath: /etc/nginx/location.d/
+          {{- if .Values.manager.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.manager.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.manager.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.manager.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      serviceAccountName: {{ template "manager.serviceAccountName" . }}
+      restartPolicy: Always
+      volumes:
+        - name: cache-volume
+          emptyDir: {}
+        - name: run-volume
+          emptyDir: {}
+        - name: auth-config
+          configMap:
+            name: auth-config
+            optional: true
+        - name: auth-secret
+          secret:
+            secretName: auth-secret
+            optional: true
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+            optional: true
+        {{- if .Values.manager.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.manager.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -133,6 +133,8 @@ spec:
               {{- end }}
             - name: run-volume
               mountPath: /var/run
+            - name: oauth-config
+              mountPath: /etc/nginx/oauth.d/
             - name: auth-config
               mountPath: /etc/nginx/auth.d/
             - name: auth-secret
@@ -152,6 +154,10 @@ spec:
           emptyDir: {}
         - name: run-volume
           emptyDir: {}
+        - name: oauth-config
+          configMap:
+            name: oauth-config
+            optional: true
         - name: auth-config
           configMap:
             name: auth-config

--- a/charts/templates/extra-list.yaml
+++ b/charts/templates/extra-list.yaml
@@ -1,0 +1,9 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/templates/extra-list.yaml
+++ b/charts/templates/extra-list.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{- range .Values.extraDeploy }}
 ---
 {{ include "common.tplvalues.render" (dict "value" . "context" $) }}

--- a/charts/templates/priorityclass-vm-preemptible.yaml
+++ b/charts/templates/priorityclass-vm-preemptible.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.priorityClass2.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+description: {{ .Values.priorityClass2.description }}
+metadata:
+  name: {{ .Values.priorityClass2.name }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+    kubevirt-manager.io/managed: "true"
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+preemptionPolicy: {{ .Values.priorityClass2.preemptionPolicy }}
+value: {{ .Values.priorityClass2.value }}
+{{- end }}
+
+

--- a/charts/templates/priorityclass-vm-standard.yaml
+++ b/charts/templates/priorityclass-vm-standard.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.priorityClass1.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+description: {{ .Values.priorityClass1.description }}
+metadata:
+  name: {{ .Values.priorityClass1.name }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+    kubevirt-manager.io/managed: "true"
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+preemptionPolicy: {{ .Values.priorityClass1.preemptionPolicy }}
+value: {{ .Values.priorityClass1.value }}
+{{- end }}
+

--- a/charts/templates/service-account.yaml
+++ b/charts/templates/service-account.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/templates/service-account.yaml
+++ b/charts/templates/service-account.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "manager.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.serviceAccount.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,8 +1,3 @@
-{{- /*
-Copyright Broadcom, Inc. All Rights Reserved.
-SPDX-License-Identifier: APACHE-2.0
-*/}}
-
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,0 +1,57 @@
+{{- /*
+Copyright Broadcom, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager
+    kubevirt-manager.io/version: {{ .Values.manager.image.tag }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" (dict "values" (list .Values.service.annotations .Values.commonAnnotations) "context" .) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: kubevirt-manager
+      port: {{ .Values.service.ports.http }}
+      {{- if not (eq .Values.service.ports.http .Values.manager.containerPorts.http) }}
+      targetPort: {{ .Values.manager.containerPorts.http }}
+      {{- end }}
+      protocol: TCP
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  {{- $podLabels := include "common.tplvalues.merge" (dict "values" (list .Values.manager.podLabels .Values.commonLabels) "context" .) | fromYaml }}
+  selector: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 4 }}
+    app.kubernetes.io/component: manager
+    app: kubevirt-manager

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -79,11 +79,10 @@ diagnosticMode:
 ## @section manager Parameters
 ##
 
-## %%MAIN_CONTAINER/POD_DESCRIPTION%%
+## manager
 ##
 manager:
-  ## Bitnami manager image
-  ## ref: https://hub.docker.com/r/bitnami/kubevirtmanager/tags/
+  ## ref: https://hub.docker.com/r/kubevirtmanager/kubevirt-manager
   ## @param manager.image.registry [default: REGISTRY_NAME] manager image registry
   ## @param manager.image.repository [default: REPOSITORY_NAME/kubevirtmanager] manager image repository
   ## @skip manager.image.tag manager image tag (immutable tags are recommended)
@@ -180,8 +179,6 @@ manager:
   customStartupProbe: {}
   ## manager resource requests and limits
   ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-  ## @param manager.resourcesPreset Set manager container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if manager.resources is set (manager.resources is recommended for production).
-  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##
   resourcesPreset: "nano"
   ## @param manager.resources Set manager container requests and limits for different resources like CPU or memory (essential for production workloads)
@@ -698,7 +695,6 @@ volumePermissions:
   ##
   enabled: false
   ## OS Shell + Utility image
-  ## ref: https://hub.docker.com/r/bitnami/os-shell/tags/
   ## @param volumePermissions.image.registry [default: REGISTRY_NAME] OS Shell + Utility image registry
   ## @param volumePermissions.image.repository [default: REPOSITORY_NAME/os-shell] OS Shell + Utility image repository
   ## @skip volumePermissions.image.tag OS Shell + Utility image tag (immutable tags are recommended)
@@ -721,7 +717,6 @@ volumePermissions:
   ## Init container's resource requests and limits
   ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
   ## @param volumePermissions.resourcesPreset Set init container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production).
-  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
   ##
   resourcesPreset: "nano"
   ## @param volumePermissions.resources Set init container requests and limits for different resources like CPU or memory (essential for production workloads)
@@ -936,7 +931,6 @@ metrics:
     ##
     relabelings: []
     ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
-    ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
     ## selector:
     ##   prometheus: my-prometheus
     ##

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -94,7 +94,7 @@ manager:
   image:
     registry: kubevirtmanager
     repository: kubevirt-manager
-    tag: 1.5.1
+    tag: 1.5.2
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,946 @@
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## e.g:
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  defaultStorageClass: ""
+  ## Security parameters
+  ##
+  security:
+    ## @param global.security.allowInsecureImages Allows skipping image verification
+    allowInsecureImages: false
+  ## Compatibility adaptations for Kubernetes platforms
+  ##
+  compatibility:
+    ## Compatibility adaptations for Openshift
+    ##
+    openshift:
+      ## @param global.compatibility.openshift.adaptSecurityContext Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+      ##
+      adaptSecurityContext: auto
+    ## @param global.compatibility.omitEmptySeLinuxOptions If set to true, removes the seLinuxOptions from the securityContexts when it is set to an empty object
+    ##
+    omitEmptySeLinuxOptions: false
+
+## @section Common parameters
+##
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param apiVersions Override Kubernetes API versions reported by .Capabilities
+##
+apiVersions: []
+## @param nameOverride String to partially override common.names.name
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+## Diagnostic mode
+## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+## @param diagnosticMode.command Command to override all containers in the chart release
+## @param diagnosticMode.args Args to override all containers in the chart release
+##
+diagnosticMode:
+  enabled: false
+  command:
+    - sleep
+  args:
+    - infinity
+
+## @section manager Parameters
+##
+
+## %%MAIN_CONTAINER/POD_DESCRIPTION%%
+##
+manager:
+  ## Bitnami manager image
+  ## ref: https://hub.docker.com/r/bitnami/kubevirtmanager/tags/
+  ## @param manager.image.registry [default: REGISTRY_NAME] manager image registry
+  ## @param manager.image.repository [default: REPOSITORY_NAME/kubevirtmanager] manager image repository
+  ## @skip manager.image.tag manager image tag (immutable tags are recommended)
+  ## @param manager.image.digest manager image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param manager.image.pullPolicy manager image pull policy
+  ## @param manager.image.pullSecrets manager image pull secrets
+  ## @param manager.image.debug Enable manager image debug mode
+  ##
+  image:
+    registry: kubevirtmanager
+    repository: kubevirt-manager
+    tag: 1.5.1
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: https://kubernetes.io/docs/concepts/containers/images/#pre-pulled-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    debug: false
+  ## @param manager.replicaCount Number of manager replicas to deploy
+  ##
+  replicaCount: 1
+  ## @param manager.containerPorts.http manager HTTP container port
+  ##
+  containerPorts:
+    http: 8080
+  ## @param manager.extraContainerPorts Optionally specify extra list of additional ports for manager containers
+  ## e.g:
+  ## extraContainerPorts:
+  ##   - name: myservice
+  ##     containerPort: 9090
+  ##
+  extraContainerPorts: []
+  ## Configure extra options for manager containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param manager.livenessProbe.enabled Enable livenessProbe on manager containers
+  ## @param manager.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param manager.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param manager.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param manager.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param manager.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: false
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 1
+    successThreshold: 5
+  ## @param manager.readinessProbe.enabled Enable readinessProbe on manager containers
+  ## @param manager.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param manager.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param manager.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param manager.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param manager.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: false
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 1
+    successThreshold: 5
+  ## @param manager.startupProbe.enabled Enable startupProbe on manager containers
+  ## @param manager.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param manager.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param manager.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param manager.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param manager.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 90
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 1
+    successThreshold: 5
+  ## @param manager.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param manager.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param manager.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## manager resource requests and limits
+  ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param manager.resourcesPreset Set manager container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if manager.resources is set (manager.resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ##
+  resourcesPreset: "nano"
+  ## @param manager.resources Set manager container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 2
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 3
+  ##     memory: 1024Mi
+  ##
+  resources: {}
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param manager.podSecurityContext.enabled Enable manager pods' Security Context
+  ## @param manager.podSecurityContext.fsGroupChangePolicy Set filesystem group change policy for manager pods
+  ## @param manager.podSecurityContext.sysctls Set kernel settings using the sysctl interface for manager pods
+  ## @param manager.podSecurityContext.supplementalGroups Set filesystem extra groups for manager pods
+  ## @param manager.podSecurityContext.fsGroup Set fsGroup in manager pods' Security Context
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroupChangePolicy: Always
+    sysctls: []
+    supplementalGroups: []
+    fsGroup: 1001
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param manager.containerSecurityContext.enabled Enabled manager container' Security Context
+  ## @param manager.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in manager container
+  ## @param manager.containerSecurityContext.runAsUser Set runAsUser in manager container' Security Context
+  ## @param manager.containerSecurityContext.readOnlyRootFilesystem Set readOnlyRootFilesystem in manager container' Security Context
+  ## @param manager.containerSecurityContext.allowPrivilegeEscalation Set allowPrivilegeEscalation in manager container' Security Context
+  ## @param manager.containerSecurityContext.runAsGroup Set runAsGroup in manager container' Security Context
+  ##
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsUser: 10000
+    runAsGroup: 30000
+
+  ## @param manager.existingConfigmap The name of an existing ConfigMap with your custom configuration for manager
+  ##
+  existingConfigmap:
+  ## @param manager.command Override default manager container command (useful when using custom images)
+  ##
+  command: []
+  ## @param manager.args Override default manager container args (useful when using custom images)
+  ##
+  args: []
+  ## @param manager.automountServiceAccountToken Mount Service Account token in manager pods
+  ##
+  automountServiceAccountToken: false
+  ## @param manager.hostAliases manager pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param manager.daemonsetAnnotations Annotations for manager daemonset
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  daemonsetAnnotations: {}
+  ## @param manager.deploymentAnnotations Annotations for manager deployment
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  deploymentAnnotations: {}
+  ## @param manager.statefulsetAnnotations Annotations for manager statefulset
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  statefulsetAnnotations: {}
+  ## @param manager.podLabels Extra labels for manager pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param manager.podAnnotations Annotations for manager pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param manager.podAffinityPreset Pod affinity preset. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param manager.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: ""
+  ## Node manager.affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param manager.nodeAffinityPreset.type Node affinity preset type. Ignored if `manager.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param manager.nodeAffinityPreset.key Node label key to match. Ignored if `manager.affinity` is set
+    ##
+    key: ""
+    ## @param manager.nodeAffinityPreset.values Node label values to match. Ignored if `manager.affinity` is set
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param manager.affinity Affinity for manager pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## NOTE: `manager.podAffinityPreset`, `manager.podAntiAffinityPreset`, and `manager.nodeAffinityPreset` will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param manager.nodeSelector Node labels for manager pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  ##
+  nodeSelector: {}
+  ## @param manager.tolerations Tolerations for manager pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## ONLY FOR DEPLOYMENTS:
+  ## @param manager.updateStrategy.type manager deployment strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  ## ONLY FOR STATEFULSETS:
+  ## @param manager.updateStrategy.type manager statefulset strategy type
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## ONLY FOR DEPLOYMENTS:
+    ## Can be set to RollingUpdate or Recreate
+    ## ONLY FOR STATEFULSETS:
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: Recreate
+  ## ONLY FOR STATEFULSETS:
+  ## @param manager.podManagementPolicy Pod management policy for manager statefulset
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: OrderedReady
+  ## @param manager.priorityClassName manager pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param manager.topologySpreadConstraints Topology Spread Constraints for manager pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: []
+  ## @param manager.schedulerName Name of the k8s scheduler (other than default) for manager pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param manager.terminationGracePeriodSeconds Seconds manager pods need to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param manager.lifecycleHooks for manager containers to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param manager.extraEnvVars Array with extra environment variables to add to manager containers
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param manager.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for manager containers
+  ##
+  extraEnvVarsCM: ""
+  ## @param manager.extraEnvVarsSecret Name of existing Secret containing extra env vars for manager containers
+  ##
+  extraEnvVarsSecret: ""
+  ## @param manager.extraVolumes Optionally specify extra list of additional volumes for the manager pods
+  ##
+  extraVolumes: []
+  ## @param manager.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the manager containers
+  ##
+  extraVolumeMounts: []
+  ## @param manager.sidecars Add additional sidecar containers to the manager pods
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param manager.initContainers Add additional init containers to the manager pods
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+  ## Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+  ## @param manager.pdb.create Enable/disable a Pod Disruption Budget creation
+  ## @param manager.pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+  ## @param manager.pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable. Defaults to `1` if both `manager.pdb.minAvailable` and `manager.pdb.maxUnavailable` are empty.
+  ##
+  pdb:
+    create: true
+    minAvailable: ""
+    maxUnavailable: ""
+  ## Autoscaling configuration
+  ## ref: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+  ##
+  autoscaling:
+    ## @param manager.autoscaling.vpa.enabled Enable VPA for manager pods
+    ## @param manager.autoscaling.vpa.annotations Annotations for VPA resource
+    ## @param manager.autoscaling.vpa.controlledResources VPA List of resources that the vertical pod autoscaler can control. Defaults to cpu and memory
+    ## @param manager.autoscaling.vpa.maxAllowed VPA Max allowed resources for the pod
+    ## @param manager.autoscaling.vpa.minAllowed VPA Min allowed resources for the pod
+    ##
+    vpa:
+      enabled: false
+      annotations: {}
+      controlledResources: []
+      maxAllowed: {}
+      minAllowed: {}
+      ## @param manager.autoscaling.vpa.updatePolicy.updateMode Autoscaling update policy
+      ## Specifies whether recommended updates are applied when a Pod is started and whether recommended updates are applied during the life of a Pod
+      ## Possible values are "Off", "Initial", "Recreate", and "Auto".
+      ##
+      updatePolicy:
+        updateMode: Auto
+    ## @param manager.autoscaling.hpa.enabled Enable HPA for manager pods
+    ## @param manager.autoscaling.hpa.minReplicas Minimum number of replicas
+    ## @param manager.autoscaling.hpa.maxReplicas Maximum number of replicas
+    ## @param manager.autoscaling.hpa.targetCPU Target CPU utilization percentage
+    ## @param manager.autoscaling.hpa.targetMemory Target Memory utilization percentage
+    ##
+    hpa:
+      enabled: false
+      minReplicas: ""
+      maxReplicas: ""
+      targetCPU: ""
+      targetMemory: ""
+
+
+## @section Traffic Exposure Parameters
+##
+
+## manager service parameters
+##
+service:
+  ## @param service.type manager service type
+  ##
+  type: ClusterIP
+  ## @param service.ports.http manager service HTTP port
+  ##
+  ports:
+    http: 8080
+  ## Node ports to expose
+  ## @param service.nodePorts.http Node port for HTTP
+  ## NOTE: choose port between <30000-32767>
+  ##
+  nodePorts:
+    http: ""
+  ## @param service.clusterIP manager service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.loadBalancerIP manager service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
+  loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges manager service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.annotations Additional custom annotations for manager service
+  ##
+  annotations: {}
+  ## @param service.extraPorts Extra ports to expose in manager service (normally used with the `sidecars` value)
+  ##
+  extraPorts: []
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
+## Network Policies
+## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created
+  ##
+  enabled: true
+  ## @param networkPolicy.allowExternal Don't require server label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## server label will have network access to the ports server is listening
+  ## on. When true, server will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.allowExternalEgress Allow the pod to access any range of port and all destinations.
+  ##
+  allowExternalEgress: true
+  ## @param networkPolicy.addExternalClientAccess Allow access from pods with client label set to "true". Ignored if `networkPolicy.allowExternal` is true.
+  ##
+  addExternalClientAccess: true
+  ## @param networkPolicy.extraIngress [array] Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  extraIngress: []
+  ## @param networkPolicy.extraEgress [array] Add extra ingress rules to the NetworkPolicy (ignored if allowExternalEgress=true)
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressPodMatchLabels [object] Labels to match to allow traffic from other pods. Ignored if `networkPolicy.allowExternal` is true.
+  ## e.g:
+  ## ingressPodMatchLabels:
+  ##   my-client: "true"
+  #
+  ingressPodMatchLabels: {}
+  ## @param networkPolicy.ingressNSMatchLabels [object] Labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
+  ## @param networkPolicy.ingressNSPodMatchLabels [object] Pod labels to match to allow traffic from other namespaces. Ignored if `networkPolicy.allowExternal` is true.
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+## manager ingress parameters
+## ref: http://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  ## @param ingress.enabled Enable ingress record generation for manager
+  ##
+  enabled: false
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: manager.local
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
+  ## @param ingress.path Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+  ##
+  path: /
+  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+  ## Use this parameter to set the required annotations for cert-manager, see
+  ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+  ## e.g:
+  ## annotations:
+  ##   kubernetes.io/ingress.class: nginx
+  ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+  ##
+  annotations: {}
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Rely on cert-manager to create it by setting the corresponding annotations
+  ##   - Rely on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
+  tls: false
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
+  ## extraHosts:
+  ##   - name: manager.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - manager.local
+  ##   secretName: manager.local-tls
+  ##
+  extraTls: []
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: manager.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
+  ## @param ingress.extraRules Additional rules to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+  ## e.g:
+  ## extraRules:
+  ## - host: example.local
+  ##     http:
+  ##       path: /
+  ##       backend:
+  ##         service:
+  ##           name: example-svc
+  ##           port:
+  ##             name: http
+  ##
+  extraRules: []
+
+## @section Persistence Parameters
+##
+
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+##
+persistence:
+  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+  ##
+  enabled: true
+  ## @param persistence.mountPath Path to mount the volume at.
+  ##
+  mountPath: /var/cache/nginx
+  ## @param persistence.subPath The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services
+  ##
+  subPath: ""
+  ## @param persistence.storageClass Storage class of backing PVC
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  ## @param persistence.annotations Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## @param persistence.accessModes Persistent Volume Access Modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.size Size of data volume
+  ##
+  size: 8Gi
+  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+  ##
+  existingClaim: ""
+  ## @param persistence.selector Selector to match an existing Persistent Volume for WordPress data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
+  ## @param persistence.dataSource Custom PVC data source
+  ##
+  dataSource: {}
+## @section Init Container Parameters
+##
+
+## 'volumePermissions' init container parameters
+## Changes the owner and group of the persistent volume mount point to runAsUser:fsGroup values
+##   based on the *podSecurityContext/*containerSecurityContext parameters
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+  ##
+  enabled: false
+  ## OS Shell + Utility image
+  ## ref: https://hub.docker.com/r/bitnami/os-shell/tags/
+  ## @param volumePermissions.image.registry [default: REGISTRY_NAME] OS Shell + Utility image registry
+  ## @param volumePermissions.image.repository [default: REPOSITORY_NAME/os-shell] OS Shell + Utility image repository
+  ## @skip volumePermissions.image.tag OS Shell + Utility image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy OS Shell + Utility image pull policy
+  ## @param volumePermissions.image.pullSecrets OS Shell + Utility image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/os-shell
+    tag: 12-debian-12-r%%IMAGE_REVISION%%
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container's resource requests and limits
+  ## ref: http://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  ## @param volumePermissions.resourcesPreset Set init container resources according to one common preset (allowed values: none, nano, small, medium, large, xlarge, 2xlarge). This is ignored if volumePermissions.resources is set (volumePermissions.resources is recommended for production).
+  ## More information: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
+  ##
+  resourcesPreset: "nano"
+  ## @param volumePermissions.resources Set init container requests and limits for different resources like CPU or memory (essential for production workloads)
+  ## Example:
+  ## resources:
+  ##   requests:
+  ##     cpu: 2
+  ##     memory: 512Mi
+  ##   limits:
+  ##     cpu: 3
+  ##     memory: 1024Mi
+  ##
+  resources: {}
+  ## Init container Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.enabled Enabled init container' Security Context
+  ## @param volumePermissions.containerSecurityContext.seLinuxOptions [object,nullable] Set SELinux options in init container
+  ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
+  ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
+  ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+  ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
+  ##
+  containerSecurityContext:
+    enabled: true
+    seLinuxOptions: {}
+    runAsUser: 0
+
+## @section Other Parameters
+##
+
+## RBAC configuration
+##
+rbac:
+  ## @param rbac.role.create Specifies whether a Role should be created 
+  role:
+    create: false
+    ## @param rbac.role.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: ""
+  ## @param rbac.clusterrole1.create Specifies whether a ClusterRole1 should be created 
+  clusterrole1:
+    create: true
+    ## @param rbac.clusterrole1.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+  ## @param rbac.clusterrole2.create Specifies whether a ClusterRole2 should be created 
+  clusterrole2:
+    create: true
+    ## @param rbac.clusterrole2.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+  ## @param rbac.clusterrole3.create Specifies whether a ClusterRole3 should be created 
+  clusterrole3:
+    create: true
+    ## @param rbac.clusterrole3.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+  ## @param rbac.clusterrole4.create Specifies whether a ClusterRole4 should be created 
+  clusterrole4:
+    create: true
+    ## @param rbac.clusterrole4.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+
+## PriorityClass1 configuration
+##
+priorityClass1:
+  ## @param priorityClass1.enabled Enable a PriorityClass1 to control the scheduling priority of operator pods
+  ##
+  enabled: true
+  ## @param priorityClass1.name The name of the PriorityClass1 to use
+  ##
+  name: vm-standard
+  ## @param priorityClass1.value The value of the PriorityClass1 to use
+  ## This value determines the priority. Higher values mean higher priority.
+  ## For example, 1000000 is higher priority than 1000.
+  ##
+  value: "999999999"
+  ## @param priorityClass1.description The description of the PriorityClass1 to use
+  ##
+  description: Priority class for VMs which should not be preemtited.
+  ## @param priorityClass1.preemptionPolicy controls the preemption behavior for the pod. 
+  ##
+  preemptionPolicy: Never
+
+## PriorityClass2 configuration
+##
+priorityClass2:
+  ## @param priorityClass2.enabled Enable a PriorityClass2 to control the scheduling priority of operator pods
+  ##
+  enabled: true
+  ## @param priorityClass2.name The name of the PriorityClass2 to use
+  ##
+  name: vm-preemptible
+  ## @param priorityClass2.value The value of the PriorityClass2 to use
+  ## This value determines the priority. Higher values mean higher priority.
+  ## For example, 1000000 is higher priority than 1000.
+  ##
+  value: "1000000"
+  ## @param priorityClass2.description The description of the PriorityClass2 to use
+  ##
+  description: Priority class for VMs which are allowed to be preemtited.
+  ## @param priorityClass2.preemptionPolicy controls the preemption behavior for the pod. 
+  ##
+  preemptionPolicy: PreemptLowerPriority
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: "kubevirt-manager"
+  ## @param serviceAccount.annotations Additional Service Account annotations (evaluated as a template)
+  ##
+  annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ##
+  automountServiceAccountToken: ""
+
+## Prometheus metrics
+##
+metrics:
+  ## @param metrics.enabled Enable the export of Prometheus metrics
+  ##
+  enabled: false
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace in which Prometheus is running
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.annotations Additional custom annotations for the ServiceMonitor
+    ##
+    annotations: {}
+    ## @param metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in Prometheus
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## interval: 10s
+    ##
+    interval: ""
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ## e.g:
+    ## scrapeTimeout: 10s
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.relabelings Specify general relabeling
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
+    ## selector:
+    ##   prometheus: my-prometheus
+    ##
+    selector: {}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,6 +1,3 @@
-# Copyright Broadcom, Inc. All Rights Reserved.
-# SPDX-License-Identifier: APACHE-2.0
-
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value


### PR DESCRIPTION
We received a request to add a Helm chart for kubevirt-manager, originally based on the Bitnami chart template (prior to the recent events/drama). The initial idea was to push the chart upstream to Bitnami, but given the current situation, that’s no longer straightforward.

This PR provides an updated Helm chart for version 1.5.2. It still depends on the _bitnami-common_ chart, but if there’s interest, we can work on removing that dependency.

In addition, the chart will need to be published ([Helm Chart Repositories](https://helm.sh/docs/topics/chart_repository/)) and there are existing GitHub Actions available that can help automate this process.
