### PR TITLE
fix: VM memory update 422 error and kubectl download failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ RUN cd /usr/src/app/src/assets/ && \
 RUN cd /usr/src/app && \
     sed -i "s|nightly|${KVM_VERSION}|g" src/app/components/main-footer/main-footer.component.html && \
     npm run build
+# Download kubectl in builder stage (fixes corrupt kubectl when nginx stage has no proxy/network)
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x kubectl
 
 # OAUTH2 IMAGE
 FROM quay.io/oauth2-proxy/oauth2-proxy:latest AS oauth2_proxy_downloader
@@ -48,9 +51,7 @@ COPY --from=oauth2_proxy_downloader /etc/ssl/private/jwt_signing_key.pem /etc/ss
 
 RUN mkdir -p /etc/nginx/location.d/ && \
     mkdir -p /etc/nginx/oauth.d/
-RUN curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin
+COPY --from=builder /usr/src/app/kubectl /usr/local/bin/kubectl
 
 COPY entrypoint/90-oauth-proxy.sh /docker-entrypoint.d
 COPY entrypoint/91-startkubectl.sh /docker-entrypoint.d
@@ -60,4 +61,3 @@ COPY conf/gzip.conf /etc/nginx/conf.d/
 RUN chmod +x /docker-entrypoint.d/90-oauth-proxy.sh && chmod +x /docker-entrypoint.d/91-startkubectl.sh
 
 COPY --from=builder /usr/src/app/dist/kubevirtmgr-webui/browser /usr/share/nginx/html
- 

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,115 @@
+# Patches for kubevirt-manager
+
+This document describes the fixes for two bugs in kubevirt-manager upstream.
+
+---
+
+## Fix 1: VM Memory Update 422 Error
+
+**File:** `src/app/services/kube-virt.service.ts`
+
+**Problem:** Modifying VM memory in the UI returns `422 Unprocessable Entity`. KubeVirt validation requires `domain.memory.guest` ≤ `resources.limits.memory`, but the original code only patched `resources.requests.memory`.
+
+**Solution:** Patch all three memory fields together in `scaleVm` and `scalePool`:
+- `domain.memory.guest`
+- `resources.requests.memory`
+- `resources.limits.memory`
+
+### Change 1.1: scaleVm (around line 150)
+
+```diff
+     scaleVm(namespace: string, name: string, cores: string, threads: string, sockets: string, memory: string): Observable<any> {
+         var baseUrl ='./k8s/apis/kubevirt.io/v1';
+         const headers = {
+             'content-type': 'application/merge-patch+json',
+             'accept': 'application/json'
+         };
++        const mem = memory + 'Gi';
+-        return this.http.patch(..., '{"spec":{"template":{"spec":{"domain":{"cpu":{...},"resources":{"requests":{"memory": "'+memory+'Gi"}}}}}}}', ...);
++        return this.http.patch(..., '{"spec":{"template":{"spec":{"domain":{"cpu":{...},"memory":{"guest":"'+mem+'"},"resources":{"requests":{"memory":"'+mem+'"},"limits":{"memory":"'+mem+'"}}}}}}}', ...);
+     }
+```
+
+### Change 1.2: scalePool (around line 297)
+
+```diff
+     scalePool(namespace: string, name: string, cores: string, threads: string, sockets: string, memory: string): Observable<any> {
+         ...
++        const mem = memory + 'Gi';
+-        return this.http.patch(..., '{"spec":{"virtualMachineTemplate":{"spec":{"template":{"spec":{"domain":{"cpu":{...},"resources":{"requests":{"memory": "'+memory+'Gi"}}}}}}}}}', ...);
++        return this.http.patch(..., '{"spec":{"virtualMachineTemplate":{"spec":{"template":{"spec":{"domain":{"cpu":{...},"memory":{"guest":"'+mem+'"},"resources":{"requests":{"memory":"'+mem+'"},"limits":{"memory":"'+mem+'"}}}}}}}}}}', ...);
+     }
+```
+
+---
+
+## Fix 2: kubectl Download Failure (Dashboard 502)
+
+**File:** `Dockerfile`
+
+**Problem:** The nginx stage runs `curl` to download kubectl from dl.k8s.io. In environments where the registry requires a proxy or has network issues, the download fails and saves an error page (~239 bytes) instead of the binary (~56MB). This corrupts `/usr/local/bin/kubectl`, kubectl proxy fails to start, and the Dashboard/VM list returns 502 Connection Refused.
+
+**Solution:** Download kubectl in the **builder** stage (which has network/proxy access for npm and git) and COPY the binary to the nginx stage.
+
+### Change 2.1: Add kubectl download in builder stage (after npm run build)
+
+```diff
+ RUN cd /usr/src/app && \
+     sed -i "s|nightly|${KVM_VERSION}|g" src/app/components/main-footer/main-footer.component.html && \
+     npm run build
++
++# Download kubectl in builder stage (reliable network/proxy for npm/git)
++RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
++    chmod +x kubectl
+
+ # OAUTH2 IMAGE
+```
+
+### Change 2.2: Replace curl in nginx stage with COPY from builder
+
+```diff
+ RUN mkdir -p /etc/nginx/location.d/ && \
+     mkdir -p /etc/nginx/oauth.d/
+-RUN curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && \
+-    chmod +x ./kubectl && \
+-    mv ./kubectl /usr/local/bin
++COPY --from=builder /usr/src/app/kubectl /usr/local/bin/kubectl
+
+ COPY entrypoint/90-oauth-proxy.sh
+```
+
+---
+
+## Optional: HTTP Proxy Support for Build (for users behind firewall)
+
+If you need to build behind an HTTP proxy, add these build args and ENV to the **builder** stage only:
+
+```dockerfile
+# Build Args
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+
+# In builder stage:
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV http_proxy=${HTTP_PROXY}
+ENV https_proxy=${HTTPS_PROXY}
+```
+
+Then build with:
+```bash
+docker build --build-arg HTTP_PROXY=http://proxy:port --build-arg HTTPS_PROXY=http://proxy:port -t kubevirt-manager:tag .
+```
+
+**Note:** This is optional and not required for the upstream PR. Keep it in your local Dockerfile if needed.
+
+---
+
+## Files to Submit for PR
+
+| File | Change |
+|------|--------|
+| `src/app/services/kube-virt.service.ts` | Fix 1 (memory patch) |
+| `Dockerfile` | Fix 2 (kubectl in builder) — use the version **without** proxy args for upstream |

--- a/src/app/services/kube-virt.service.ts
+++ b/src/app/services/kube-virt.service.ts
@@ -153,7 +153,8 @@ export class KubeVirtService {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
         };
-        return this.http.patch(`${baseUrl}/namespaces/${namespace}/virtualmachines/${name}`, '{"spec":{"template":{"spec":{"domain":{"cpu":{"sockets": '+sockets+',"cores": '+cores+',"threads": '+threads+'},"resources":{"requests":{"memory": "'+memory+'Gi"}}}}}}}', { 'headers': headers } );
+        const mem = memory + 'Gi';
+        return this.http.patch(`${baseUrl}/namespaces/${namespace}/virtualmachines/${name}`, '{"spec":{"template":{"spec":{"domain":{"cpu":{"sockets": '+sockets+',"cores": '+cores+',"threads": '+threads+'},"memory":{"guest":"'+mem+'"},"resources":{"requests":{"memory":"'+mem+'"},"limits":{"memory":"'+mem+'"}}}}}}}', { 'headers': headers } );
     }
 
     changeVmStrategy(namespace: string, name: string, strategy: string): Observable<any> {
@@ -299,7 +300,8 @@ export class KubeVirtService {
             'content-type': 'application/merge-patch+json',
             'accept': 'application/json'
         };
-        return this.http.patch(`${baseUrl}/namespaces/${namespace}/virtualmachinepools/${name}`, '{"spec":{"virtualMachineTemplate":{"spec":{"template":{"spec":{"domain":{"cpu":{"sockets": '+sockets+',"cores": '+cores+',"threads": '+threads+'},"resources":{"requests":{"memory": "'+memory+'Gi"}}}}}}}}}', { 'headers': headers } );
+        const mem = memory + 'Gi';
+        return this.http.patch(`${baseUrl}/namespaces/${namespace}/virtualmachinepools/${name}`, '{"spec":{"virtualMachineTemplate":{"spec":{"template":{"spec":{"domain":{"cpu":{"sockets": '+sockets+',"cores": '+cores+',"threads": '+threads+'},"memory":{"guest":"'+mem+'"},"resources":{"requests":{"memory":"'+mem+'"},"limits":{"memory":"'+mem+'"}}}}}}}}}}', { 'headers': headers } );
     }
 
     createPool(virtualMachinePool: VirtualMachinePool): Observable<any> {


### PR DESCRIPTION
## Problem

1. **422 Unprocessable Entity** when modifying VM memory in the UI — KubeVirt requires `domain.memory.guest` ≤ `resources.limits.memory`, but only `resources.requests.memory` was being patched.

2. **Dashboard 502 / empty VM list** — kubectl proxy fails because `/usr/local/bin/kubectl` is corrupt (~239 bytes HTML error page instead of ~56MB binary). The nginx stage's `curl` for kubectl fails when dl.k8s.io needs a proxy or has network issues.

## Solution

1. **kube-virt.service.ts**: Patch `domain.memory.guest`, `resources.requests.memory`, and `resources.limits.memory` together in `scaleVm` and `scalePool`.

2. **Dockerfile**: Download kubectl in the builder stage (same stage that runs npm/git) and COPY to the nginx stage, instead of curling in the nginx stage.

See PATCHES.md for change annotations.