### PR TITLE
build multi-arch container images in CI

### DIFF
--- a/.github/workflows/testbuild.yaml
+++ b/.github/workflows/testbuild.yaml
@@ -36,3 +36,19 @@ jobs:
       run: npm run build
     - name: Final Cleanup
       run: npm run clean
+
+  container-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build container images
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ FROM quay.io/oauth2-proxy/oauth2-proxy:latest AS oauth2_proxy_downloader
 
 # NGINX Image
 FROM docker.io/nginx:1.29-alpine
+ARG TARGETARCH
 LABEL org.opencontainers.image.authors="marcelo@feitoza.com.br"
 LABEL description="Kubevirt Manager ${KVM_VERSION}"
 
@@ -48,7 +49,7 @@ COPY --from=oauth2_proxy_downloader /etc/ssl/private/jwt_signing_key.pem /etc/ss
 
 RUN mkdir -p /etc/nginx/location.d/ && \
     mkdir -p /etc/nginx/oauth.d/
-RUN curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin
 
@@ -60,4 +61,3 @@ COPY conf/gzip.conf /etc/nginx/conf.d/
 RUN chmod +x /docker-entrypoint.d/90-oauth-proxy.sh && chmod +x /docker-entrypoint.d/91-startkubectl.sh
 
 COPY --from=builder /usr/src/app/dist/kubevirtmgr-webui/browser /usr/share/nginx/html
- 


### PR DESCRIPTION
## Problem

The release workflow already asks Buildx to publish both `linux/amd64` and `linux/arm64`, but the final image always downloads the amd64 `kubectl` binary. As a result, the arm64 image can be assembled with an architecture-mismatched helper binary and fail when the entrypoint starts the Kubernetes proxy.

The pull request workflow only builds the Angular artifact, so it does not exercise either container platform and cannot catch this regression before a release.

## Fix

- Use BuildKit's `TARGETARCH` argument when downloading `kubectl` so every image gets the matching binary.
- Add a pull request container-build job with QEMU and Buildx.
- Build both `linux/amd64` and `linux/arm64` in that job without pushing images.

The existing release tags and publication behavior are unchanged.

## Validation

- `git diff --check`
- Parsed both changed GitHub Actions workflows as YAML.
- Ran `docker buildx build --platform linux/amd64,linux/arm64 --output type=cacheonly .` successfully.
- Confirmed from the Buildx log that the arm64 stage downloads from the `bin/linux/arm64/kubectl` path and the amd64 stage uses `bin/linux/amd64/kubectl`.
