### PR TITLE
fix: validate Image name for DNS-1123 compliance

### DIFF
--- a/src/app/components/images/images.component.ts
+++ b/src/app/components/images/images.component.ts
@@ -86,6 +86,12 @@ export class ImagesComponent implements OnInit {
      * Create the new image
      */
     async applyNew(name: string, namespace: string, type: string, credentials: string, readableName: string, readableDescription: string, value: string): Promise<void> {
+        let k8sNameRegex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+        if (!k8sNameRegex.test(name)) {
+            this.myToasts.toastError("Images", "", "Image name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character.");
+            return;
+        }
+
         if(name != "" && namespace != "" && type != "" && readableName != "" && value != "") {
             let myImage: Image = {
                 apiVersion: 'kubevirt-manager.io/v1',


### PR DESCRIPTION
## Problem
Currently, the UI does not validate if the image name follows Kubernetes DNS-1123 subdomain rules (lowercase, alphanumeric, no spaces, no underscores).
If a user enters an invalid name (like `RHEL Image`), the Kubernetes API rejects it with a `422 Unprocessable Entity` error, but the UI simply displays a confusing `Http failure response ... 422 OK`.

## Solution
This PR adds a regex validation step inside `applyNew` in `images.component.ts` to verify the name follows DNS-1123 constraints. If it fails, it displays a clear error using the toast service and prevents the API request from being sent.

Fixes #153
