### PR TITLE
fix: gracefully handle 409 Conflict when creating DataVolumes

### DIFF
--- a/src/app/components/disk-list/disk-list.component.ts
+++ b/src/app/components/disk-list/disk-list.component.ts
@@ -327,7 +327,11 @@ export class DiskListComponent implements OnInit {
                 this.myToasts.toastSuccess(this.pageName, "", "Created Data Volume: " + diskName);
                 this.fullReload();
             } catch (e: any) {
-                this.myToasts.toastError(this.pageName, "", e.message);
+                if (e.status === 409) {
+                    this.myToasts.toastError(this.pageName, "Conflict", `DataVolume disk "${diskName}" already exists. Please choose a different disk name or clean up the existing disk.`);
+                } else {
+                    this.myToasts.toastError(this.pageName, "", e.message);
+                }
                 console.log(e);
             }
         }

--- a/src/app/components/vmlist/vmlist.component.ts
+++ b/src/app/components/vmlist/vmlist.component.ts
@@ -887,7 +887,11 @@ export class VmlistComponent implements OnInit {
                         disks.push(diskObject);
                         console.log(diskObject)
                     } catch (e: any) {
-                        this.myToasts.toastError(this.pageName, "", e.message);
+                        if (e.status === 409) {
+                            this.myToasts.toastError(this.pageName, "Conflict", `DataVolume disk "${actualDiskName}" already exists. Please choose a different VM name or clean up the existing disk.`);
+                        } else {
+                            this.myToasts.toastError(this.pageName, "", e.message);
+                        }
                         console.log(e);
                         throw new Error("Error creating disk" + i.toString() + " from Image!");
                     }
@@ -915,7 +919,11 @@ export class VmlistComponent implements OnInit {
                         disks.push(diskObject);
                         console.log(diskObject)
                     } catch (e: any) {
-                        this.myToasts.toastError(this.pageName, "", e.message);
+                        if (e.status === 409) {
+                            this.myToasts.toastError(this.pageName, "Conflict", `DataVolume disk "${actualDiskName}" already exists. Please choose a different VM name or clean up the existing disk.`);
+                        } else {
+                            this.myToasts.toastError(this.pageName, "", e.message);
+                        }
                         console.log(e);
                         throw new Error("Error creating disk" + i.toString() + " from Blank!");
                     }


### PR DESCRIPTION
Fixes #151. Catch 409 Conflict HTTP errors during VM and disk creation instead of surfacing raw HTTP error toasts, making the error actionable.